### PR TITLE
Add Travis, Issue, and License badge to README 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+dist: trusty
+sudo: false
+
+language: node_js
+node_js:
+  - '8'
+
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+
+cache:
+  directories:
+    - ./node_modules
+
+install:
+  - npm install
+
+script:
+  - npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessNoSandbox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# VisitingCardFront
+<h1 align='center'>Visiting Card Front</h1>
+
+<p align='center'>
+<a href="https://travis-ci.com/JBossOutreach/visiting-card-front"><img src="https://img.shields.io/travis/com/JBossOutreach/visiting-card-front.svg?style=for-the-badge"></a>
+<a href="https://github.com/JBossOutreach/visiting-card-front/issues"><img src="https://img.shields.io/github/issues/JBossOutreach/visiting-card-front.svg?style=for-the-badge"></a>
+<a href="https://github.com/JBossOutreach/visiting-card-front/network/members"><img src="https://img.shields.io/github/forks/JBossOutreach/visiting-card-front.svg?style=for-the-badge"></a>
+</p>
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.1.2.
 

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -21,6 +21,12 @@ module.exports = function (config) {
       fixWebpackSourcePaths: true
     },
     reporters: ['progress', 'kjhtml'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,


### PR DESCRIPTION
Successfully configure Angular project to Travis-CI.

Added Travis so that we are going to build Node 8 application (Angular). Travis will install stable version of Google Chrome (needed for testing) and cache content of node_modules directory. 


![image](https://user-images.githubusercontent.com/42104907/68526990-0a8f3300-0308-11ea-9d7b-09a143da4a62.png)
